### PR TITLE
Filesystem

### DIFF
--- a/filesystem.go
+++ b/filesystem.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 // FileSystem defines the methods of an abstract filesystem.
@@ -18,12 +19,8 @@ type FileSystem interface {
 	// makes no attempt to follow the link.
 	Lstat(name string) (os.FileInfo, error)
 
-	// Join joins any number of path elements into a single path, adding a
-	// separator if necessary. The result is Cleaned; in particular, all
-	// empty strings are ignored.
-	//
-	// The separator is FileSystem specific.
-	Join(elem ...string) string
+	// PathSeparator returns the FileSystem specific path separator.
+	PathSeparator() byte
 }
 
 // fs represents a FileSystem provided by the os package.
@@ -33,4 +30,17 @@ func (f *fs) ReadDir(dirname string) ([]os.FileInfo, error) { return ioutil.Read
 
 func (f *fs) Lstat(name string) (os.FileInfo, error) { return os.Lstat(name) }
 
-func (f *fs) Join(elem ...string) string { return filepath.Join(elem...) }
+func (f *fs) PathSeparator() byte { return os.PathSeparator }
+
+// Join joins any number of path elements into a single path, adding
+// a Separator if necessary. The result is Cleaned, in particular
+// all empty strings are ignored.
+func Join(fs FileSystem, elem ...string) string {
+	sep := string(fs.PathSeparator())
+	for i, e := range elem {
+		if e != "" {
+			return filepath.Clean(strings.Join(elem[i:], sep))
+		}
+	}
+	return ""
+}

--- a/filesystem_test.go
+++ b/filesystem_test.go
@@ -1,0 +1,65 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package fs
+
+import (
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+type JoinTest struct {
+	elem []string
+	path string
+}
+
+var jointests = []JoinTest{
+	// zero parameters
+	{[]string{}, ""},
+
+	// one parameter
+	{[]string{""}, ""},
+	{[]string{"a"}, "a"},
+	// one parameter
+	{[]string{""}, ""},
+	{[]string{"a"}, "a"},
+
+	// two parameters
+	{[]string{"a", "b"}, "a/b"},
+	{[]string{"a", ""}, "a"},
+	{[]string{"", "b"}, "b"},
+	{[]string{"/", "a"}, "/a"},
+	{[]string{"/", ""}, "/"},
+	{[]string{"a/", "b"}, "a/b"},
+	{[]string{"a/", ""}, "a"},
+	{[]string{"", ""}, ""},
+}
+
+var winjointests = []JoinTest{
+	{[]string{`directory`, `file`}, `directory\file`},
+	{[]string{`C:\Windows\`, `System32`}, `C:\Windows\System32`},
+	{[]string{`C:\Windows\`, ``}, `C:\Windows`},
+	{[]string{`C:\`, `Windows`}, `C:\Windows`},
+	{[]string{`C:`, `Windows`}, `C:\Windows`},
+	{[]string{`\\host\share`, `foo`}, `\\host\share\foo`},
+	{[]string{`//host/share`, `foo/bar`}, `\\host\share\foo\bar`},
+}
+
+// join takes a []string and passes it to Join.
+func join(elem []string, args ...string) string {
+	args = elem
+	return Join(new(fs), args...)
+}
+
+func TestJoin(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		jointests = append(jointests, winjointests...)
+	}
+	for _, test := range jointests {
+		if p := join(test.elem); p != filepath.FromSlash(test.path) {
+			t.Errorf("join(%q) = %q, want %q", test.elem, p, test.path)
+		}
+	}
+}

--- a/walk.go
+++ b/walk.go
@@ -51,7 +51,7 @@ func (w *Walker) Step() bool {
 			w.stack = append(w.stack, w.cur)
 		} else {
 			for i := len(list) - 1; i >= 0; i-- {
-				path := w.fs.Join(w.cur.path, list[i].Name())
+				path := Join(w.fs, w.cur.path, list[i].Name())
 				w.stack = append(w.stack, item{path, list[i], nil})
 			}
 		}

--- a/walk_test.go
+++ b/walk_test.go
@@ -10,7 +10,7 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/kr/fs"
+	 "github.com/kr/fs"
 )
 
 type PathTest struct {


### PR DESCRIPTION
Update #3
- Remove FileSystem.Join
- Add Filesystem.PathSeparator
- Add fs.Join package level func
- Walker now uses Join(fs, ...)
